### PR TITLE
fix: create mask pipeline when mask enabled after initial setup

### DIFF
--- a/depth_map_generator/operators/setup.py
+++ b/depth_map_generator/operators/setup.py
@@ -71,7 +71,7 @@ class DEPTHMAP_OT_setup(Operator):
                         self.report({'WARNING'}, "Node setup incomplete - rebuilding")
                         settings.setup_complete = False
                         return self.execute(context)
-                except Exception as e:
+                except RuntimeError as e:
                     self.report(
                         {'WARNING'},
                         f"Depth update OK, but mask failed: {str(e)}"

--- a/depth_map_generator/operators/setup.py
+++ b/depth_map_generator/operators/setup.py
@@ -64,11 +64,18 @@ class DEPTHMAP_OT_setup(Operator):
                         )
 
             else:
-                # Update existing nodes
-                if not nodes.update_depth_nodes(tree, settings, prefs):
-                    self.report({'WARNING'}, "Node setup incomplete - rebuilding")
-                    settings.setup_complete = False
-                    return self.execute(context)
+                # Update existing nodes (may also create mask pipeline
+                # if mask was enabled after initial setup)
+                try:
+                    if not nodes.update_depth_nodes(tree, settings, prefs):
+                        self.report({'WARNING'}, "Node setup incomplete - rebuilding")
+                        settings.setup_complete = False
+                        return self.execute(context)
+                except Exception as e:
+                    self.report(
+                        {'WARNING'},
+                        f"Depth update OK, but mask failed: {str(e)}"
+                    )
 
             settings.setup_complete = True
             self.report({'INFO'}, "Depth map setup complete")

--- a/depth_map_generator/utils/nodes.py
+++ b/depth_map_generator/utils/nodes.py
@@ -392,7 +392,7 @@ def create_mask_pipeline(tree, settings, prefs=None):
 
     # Create mask file output
     output_dir = paths.get_mask_output_dir(settings, prefs)
-    paths.resolve_output_path(output_dir, create=True, prefs=None)
+    paths.resolve_output_path(output_dir, create=True, prefs=prefs)
 
     mask_file_output = tree.nodes.new(type='CompositorNodeOutputFile')
     mask_file_output.name = "DM_MaskFileOutput"
@@ -455,17 +455,24 @@ def update_depth_nodes(tree, settings, prefs=None):
             is_anim=settings.render_animation
         )
 
-    # Update mask file output path
+    # Update or create mask pipeline
     mask_file_output = find_dm_node(tree, "DM_MaskFileOutput")
-    if mask_file_output and settings.mask_enabled:
-        mask_output_dir = paths.get_mask_output_dir(settings, prefs)
-        paths.resolve_output_path(mask_output_dir, create=True, prefs=None)
-        color_mode = 'RGBA' if settings.mask_output_format == 'RGBA_PNG' else 'BW'
-        prefix = "mask_" if settings.render_animation else "mask_map"
-        configure_file_output(
-            mask_file_output, mask_output_dir, prefix,
-            bit_depth=settings.output_bit_depth, color_mode=color_mode,
-            is_anim=settings.render_animation
-        )
+    if settings.mask_enabled:
+        if mask_file_output:
+            # Update existing mask file output path
+            mask_output_dir = paths.get_mask_output_dir(settings, prefs)
+            paths.resolve_output_path(mask_output_dir, create=True, prefs=prefs)
+            color_mode = 'RGBA' if settings.mask_output_format == 'RGBA_PNG' else 'BW'
+            prefix = "mask_" if settings.render_animation else "mask_map"
+            configure_file_output(
+                mask_file_output, mask_output_dir, prefix,
+                bit_depth=settings.output_bit_depth, color_mode=color_mode,
+                is_anim=settings.render_animation
+            )
+        else:
+            # Mask was enabled after initial setup — create the pipeline now.
+            # Errors are intentionally not caught here so the caller (setup
+            # operator) can report them to the user.
+            create_mask_pipeline(tree, settings, prefs)
 
     return True

--- a/depth_map_generator/utils/nodes.py
+++ b/depth_map_generator/utils/nodes.py
@@ -469,10 +469,21 @@ def update_depth_nodes(tree, settings, prefs=None):
                 bit_depth=settings.output_bit_depth, color_mode=color_mode,
                 is_anim=settings.render_animation
             )
+            # Sync mask index threshold to comparator node
+            compare_node = find_dm_node(tree, "DM_MaskCompare")
+            if compare_node:
+                compare_node.inputs[1].default_value = float(settings.mask_index)
         else:
             # Mask was enabled after initial setup — create the pipeline now.
             # Errors are intentionally not caught here so the caller (setup
             # operator) can report them to the user.
             create_mask_pipeline(tree, settings, prefs)
+    elif mask_file_output:
+        # Mask was disabled after setup — remove stale mask pipeline nodes
+        for name in ("DM_MaskFileOutput", "DM_MaskRenderLayers", "DM_MaskCompare",
+                     "DM_Cryptomatte"):
+            node = find_dm_node(tree, name)
+            if node:
+                tree.nodes.remove(node)
 
     return True


### PR DESCRIPTION
update_depth_nodes() only updated existing mask nodes but never created missing ones. When a user enabled the mask after the first Setup click, subsequent Setup calls took the update path and silently skipped the mask pipeline entirely — no DM_MaskFileOutput node was ever created, so no mask file was written to disk.

- update_depth_nodes() now calls create_mask_pipeline() when mask_enabled=True but DM_MaskFileOutput doesn't exist
- Pass prefs (not None) to resolve_output_path for mask paths so the auto_create_directories preference is respected
- Wrap the update path in setup.py with try/except so a mask creation failure is reported as a warning instead of crashing the entire setup