### PR TITLE
fix: wire output path validation and remove dead is_anim parameter

### DIFF
--- a/depth_map_generator/operators/mask_export.py
+++ b/depth_map_generator/operators/mask_export.py
@@ -66,7 +66,6 @@ class DEPTHMAP_OT_export_mask(Operator):
                     scene.frame_end = settings.frame_end
 
                 frame_count = scene.frame_end - scene.frame_start + 1
-                output_dir = paths.get_mask_output_dir(settings, prefs)
                 self.report(
                     {'INFO'},
                     f"Exporting mask animation: {frame_count} frames to {output_dir}"

--- a/depth_map_generator/operators/mask_export.py
+++ b/depth_map_generator/operators/mask_export.py
@@ -52,6 +52,13 @@ class DEPTHMAP_OT_export_mask(Operator):
                 )
                 return {'CANCELLED'}
 
+            # Validate output path before committing to a render
+            output_dir = paths.get_mask_output_dir(settings, prefs)
+            is_valid, error_msg = paths.validate_output_path(output_dir)
+            if not is_valid:
+                self.report({'ERROR'}, f"Invalid mask output path: {error_msg}")
+                return {'CANCELLED'}
+
             # Render — mask animation is independent of depth output method
             if settings.render_animation:
                 if not settings.use_scene_frame_range:

--- a/depth_map_generator/operators/render.py
+++ b/depth_map_generator/operators/render.py
@@ -43,7 +43,6 @@ class DEPTHMAP_OT_render(Operator):
                     scene.frame_end = settings.frame_end
 
                 frame_count = scene.frame_end - scene.frame_start + 1
-                output_dir = paths.get_depth_output_dir(settings, prefs)
                 self.report(
                     {'INFO'},
                     f"Rendering depth animation: {frame_count} frames to {output_dir}"

--- a/depth_map_generator/operators/render.py
+++ b/depth_map_generator/operators/render.py
@@ -24,6 +24,17 @@ class DEPTHMAP_OT_render(Operator):
             if not settings.setup_complete:
                 bpy.ops.depthmap.setup()
 
+            # Validate output path when using file output
+            if settings.depth_output_method == 'FILE_OUTPUT':
+                output_dir = paths.get_depth_output_dir(settings, prefs)
+                is_valid, error_msg = paths.validate_output_path(output_dir)
+                if not is_valid:
+                    self.report(
+                        {'ERROR'},
+                        f"Invalid depth output path: {error_msg}"
+                    )
+                    return {'CANCELLED'}
+
             if (settings.depth_output_method == 'FILE_OUTPUT'
                     and settings.render_animation):
                 # Set custom frame range if not using scene range

--- a/depth_map_generator/utils/nodes.py
+++ b/depth_map_generator/utils/nodes.py
@@ -32,7 +32,7 @@ def clear_all_nodes(tree):
 
 
 def configure_file_output(node, base_path, prefix, bit_depth='16',
-                          color_mode='BW', is_anim=False):
+                          color_mode='BW'):
     """Centralized FileOutput node configuration.
 
     Args:
@@ -41,7 +41,6 @@ def configure_file_output(node, base_path, prefix, bit_depth='16',
         prefix: Filename prefix (e.g. "depth_" or "depth_map")
         bit_depth: '8' or '16'
         color_mode: 'BW' or 'RGBA'
-        is_anim: If True, uses prefix for frame numbering; otherwise single file
     """
     # Ensure base_path ends with a separator so Blender treats it as a
     # directory, not a filename prefix.
@@ -303,8 +302,7 @@ def create_output_nodes(tree, settings, output_socket, prefs=None):
         prefix = "depth_" if settings.render_animation else "depth_map"
         configure_file_output(
             file_output, output_dir, prefix,
-            bit_depth=bit_depth, color_mode='BW',
-            is_anim=settings.render_animation
+            bit_depth=bit_depth, color_mode='BW'
         )
 
     # Optional preview viewer alongside file output
@@ -408,8 +406,7 @@ def create_mask_pipeline(tree, settings, prefs=None):
     prefix = "mask_" if settings.render_animation else "mask_map"
     configure_file_output(
         mask_file_output, output_dir, prefix,
-        bit_depth=settings.output_bit_depth, color_mode=color_mode,
-        is_anim=settings.render_animation
+        bit_depth=settings.output_bit_depth, color_mode=color_mode
     )
 
 
@@ -451,8 +448,7 @@ def update_depth_nodes(tree, settings, prefs=None):
         prefix = "depth_" if settings.render_animation else "depth_map"
         configure_file_output(
             file_output, output_dir, prefix,
-            bit_depth=settings.output_bit_depth, color_mode='BW',
-            is_anim=settings.render_animation
+            bit_depth=settings.output_bit_depth, color_mode='BW'
         )
 
     # Update or create mask pipeline
@@ -466,8 +462,7 @@ def update_depth_nodes(tree, settings, prefs=None):
             prefix = "mask_" if settings.render_animation else "mask_map"
             configure_file_output(
                 mask_file_output, mask_output_dir, prefix,
-                bit_depth=settings.output_bit_depth, color_mode=color_mode,
-                is_anim=settings.render_animation
+                bit_depth=settings.output_bit_depth, color_mode=color_mode
             )
             # Sync mask index threshold to comparator node
             compare_node = find_dm_node(tree, "DM_MaskCompare")


### PR DESCRIPTION
- Add validate_output_path() call in mask_export.py before rendering
- Add validate_output_path() call in render.py for FILE_OUTPUT mode
- Remove unused is_anim parameter from configure_file_output and all 4 call sites in nodes.py